### PR TITLE
Update style.css - fix bug - gmap's map disapear in high and negative contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1464,3 +1464,4 @@ body.rtl .pojo-skip-link:focus {
   right: 50px;
   left: auto;
 }
+


### PR DESCRIPTION
body.pojo-a11y-high-contrast div#gmap, body.pojo-a11y-high-contrast div#gmap *,
body .pojo-a11y-negative-contrast div#gmap, body.pojo-a11y-negative-contrast div#gmap *{
    background: initial !important;
}